### PR TITLE
fix: Send the correct data for `on` callbacks

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Install Deno
         uses: denolib/setup-deno@master
 
-#      - name: Lint
-#        run: deno lint --unstable
+      - name: Lint
+        run: deno lint --unstable
 
       - name: Formatter
         run: deno fmt --check

--- a/README.md
+++ b/README.md
@@ -52,14 +52,19 @@ await Dami.connectAndLogin(myUser) // Connect and Login to the pbx
 
 await Dami.listen() // Start listening for events. Required to register listeners
 
+Dami.on("FullyBooted", (data: DAMIData)  => { // event for when you authenticate
+  console.log("Auth response:")
+  console.log(data)
+})
+
 Dami.on("Hangup", async (data: DAMIData) => {
   console.log("A hangup was made. Here is the data the AMI sent back:")
   console.log(data) // { Event: "Hangup", ... }
   await Dami.to("Originate",  {
-    Channel: "sip/12345"
-    Exten: 1234
+    Channel: "sip/12345",
+    Exten: 1234,
     Context: "default"
-  }
+  })
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ await Dami.connectAndLogin(myUser) // Connect and Login to the pbx
 
 await Dami.listen() // Start listening for events. Required to register listeners
 
-Dami.on("FullyBooted", (data: DAMIData)  => { // event for when you authenticate
+Dami.on("FullyBooted", (data: DAMIData)  => { // event for when you authenticate (or fail to)
   console.log("Auth response:")
   console.log(data)
 })
@@ -66,6 +66,12 @@ Dami.on("Hangup", async (data: DAMIData) => {
     Context: "default"
   })
 })
+
+// Send an action to the AMI to get an event
+Dami.on("PeerEntry", (data: DAMIData) => { // If you have multiple peers, this cb will be called for each one
+  console.log(data) // { ObjectName: 6002, Event: "PeerEntry", ... }
+})
+Dami.to("SIPPeers", {})
 ```
 
 ## Documentation

--- a/src/dami.ts
+++ b/src/dami.ts
@@ -164,7 +164,9 @@ export class DAMI {
         );
         try {
           this.conn!.close();
-        } catch  (err) {}
+        } catch  (err) {
+          // do nothing
+        }
       }
     })();
   }

--- a/src/dami.ts
+++ b/src/dami.ts
@@ -10,10 +10,6 @@ interface IConfigs {
 
 type LogLevels = "error" | "info" | "log";
 
-const actionEventPairs: {[key: string]: string[]} = {
-  SIPPeers: ["PeerEntry", "PeerListComplete"]
-}
-
 export interface DAMIData {
   [key: string]: string | number | string[];
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "8089:8089"
       - "5038:5038" # asterisk ami (manager.conf)
     volumes:
-      #- "./.docker/config/asterisk/sip.conf:/etc/asterisk/sip.conf"
+      - "./sip.conf:/etc/asterisk/sip.conf"
       #- "./.docker/config/asterisk/extensions.conf:/etc/asterisk/extensions.conf"
      # - "./.docker/config/asterisk/pjsip.conf:/etc/asterisk/pjsip.conf"
       - "./rtp.conf:/etc/asterisk/rtp.conf"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   asterisk:
-    container_name: asterisk_pbx
+    container_name: dami_pbx
     image: hibou/asterisk:14
     ports:
       - "5060:5060/udp"

--- a/tests/integration/connects_and_listens_test.ts
+++ b/tests/integration/connects_and_listens_test.ts
@@ -1,4 +1,4 @@
-import { DAMI } from "../../src/dami.ts";
+import {DAMI, DAMIData} from "../../src/dami.ts";
 import { Rhum } from "../deps.ts";
 
 const ami = {
@@ -12,47 +12,45 @@ const auth = {
   secret: "mysecret",
 };
 
-Deno.test({
-  name: "Can connect, login, and receieve events",
-  sanitizeOps: false,
-  sanitizeResources: false,
-  async fn(): Promise<void> {
-    // Assert connection and login
-    const Dami = new DAMI(ami);
-    await Dami.connectAndLogin(auth);
-    await Dami.listen();
-    let res: any = {};
-    Dami.on("FullyBooted", (data) => {
-      res = data;
-      Dami.close();
-    });
-    await setTimeout(() => {
-      Rhum.asserts.assertEquals(res.Event, "FullyBooted");
-      Rhum.asserts.assertEquals(res.Message, "Authentication accepted");
-      Dami.close();
-    }, 2000);
-  },
-});
+function sleep(milliseconds: number) {
+  var start = new Date().getTime();
+  for (var i = 0; i < 1e7; i++) {
+    if ((new Date().getTime() - start) > milliseconds){
+      break;
+    }
+  }
+}
 
 Deno.test({
-  name: "Can send events",
+  name: "Can connect, login and receieve/send events",
   sanitizeOps: false,
   sanitizeResources: false,
   async fn(): Promise<void> {
-    // Assert sending  events
+    // Can connect and login
     const Dami = new DAMI(ami);
     await Dami.connectAndLogin(auth);
-    await Dami.listen();
+    // Can receive events
     let res: any = {};
-    Dami.on("PeerlistComplete", (data) => {
+    const peerEntryResults: any = [];
+    Dami.on("FullyBooted", (data) => {
       res = data;
-      Dami.close();
     });
-    await Dami.to("SIPPeers", {});
+    Dami.on("PeerEntry", (data) => {
+      peerEntryResults.push(data)
+    })
+    await Dami.listen();
+    await setTimeout(() =>  {
+      Rhum.asserts.assertEquals(res.Event, "FullyBooted");
+      Rhum.asserts.assertEquals(res.Message, "Authentication accepted");
+    },  2000)
+
+    // can send/trigger events
+    Dami.to("SIPPeers", {})
     await setTimeout(() => {
-      Rhum.asserts.assertEquals(res.Event, "PeerlistComplete");
-      Rhum.asserts.assertEquals(res.Message, "Peer status list will follow");
-      Dami.close();
-    }, 2000);
+      Rhum.asserts.assertEquals(peerEntryResults.length, 2);
+      Rhum.asserts.assertEquals(peerEntryResults[0].ObjectName, 6001)
+      Rhum.asserts.assertEquals(peerEntryResults[1].ObjectName, 6002)
+      Dami.close()
+    },  2000)
   },
 });

--- a/tests/integration/connects_and_listens_test.ts
+++ b/tests/integration/connects_and_listens_test.ts
@@ -1,4 +1,4 @@
-import {DAMI, DAMIData} from "../../src/dami.ts";
+import { DAMI, DAMIData } from "../../src/dami.ts";
 import { Rhum } from "../deps.ts";
 
 const ami = {
@@ -15,7 +15,7 @@ const auth = {
 function sleep(milliseconds: number) {
   var start = new Date().getTime();
   for (var i = 0; i < 1e7; i++) {
-    if ((new Date().getTime() - start) > milliseconds){
+    if ((new Date().getTime() - start) > milliseconds) {
       break;
     }
   }
@@ -36,21 +36,21 @@ Deno.test({
       res = data;
     });
     Dami.on("PeerEntry", (data) => {
-      peerEntryResults.push(data)
-    })
+      peerEntryResults.push(data);
+    });
     await Dami.listen();
-    await setTimeout(() =>  {
+    await setTimeout(() => {
       Rhum.asserts.assertEquals(res.Event, "FullyBooted");
       Rhum.asserts.assertEquals(res.Message, "Authentication accepted");
-    },  2000)
+    }, 2000);
 
     // can send/trigger events
-    Dami.to("SIPPeers", {})
+    Dami.to("SIPPeers", {});
     await setTimeout(() => {
       Rhum.asserts.assertEquals(peerEntryResults.length, 2);
-      Rhum.asserts.assertEquals(peerEntryResults[0].ObjectName, 6001)
-      Rhum.asserts.assertEquals(peerEntryResults[1].ObjectName, 6002)
-      Dami.close()
-    },  2000)
+      Rhum.asserts.assertEquals(peerEntryResults[0].ObjectName, 6001);
+      Rhum.asserts.assertEquals(peerEntryResults[1].ObjectName, 6002);
+      Dami.close();
+    }, 2000);
   },
 });

--- a/tests/integration/connects_and_listens_test.ts
+++ b/tests/integration/connects_and_listens_test.ts
@@ -30,7 +30,9 @@ Deno.test({
     const Dami = new DAMI(ami);
     await Dami.connectAndLogin(auth);
     // Can receive events
+    // deno-lint-ignore no-explicit-any
     let res: any = {};
+    // deno-lint-ignore no-explicit-any
     const peerEntryResults: any = [];
     Dami.on("FullyBooted", (data) => {
       res = data;

--- a/tests/sip.conf
+++ b/tests/sip.conf
@@ -1,0 +1,15 @@
+[general]
+transport=udp
+
+[friends_internal](!)
+type=friend
+host=dynamic
+context=from-internal
+disallow=all
+allow=ulaw
+
+[6001](friends_internal)
+secret=verysecretpassword ; put a strong, unique password here instead
+
+[6002](friends_internal)
+secret=othersecretpassword ; put a strong, unique password here instead

--- a/tests/unit/dami_test.ts
+++ b/tests/unit/dami_test.ts
@@ -12,7 +12,7 @@ const auth = {
   secret: "mysecret",
 };
 
-Rhum.testPlan("tests/unit/dami.ts", () => {
+Rhum.testPlan("tests/unit/dami_test.ts", () => {
   Rhum.testSuite("close()", () => {
     Rhum.testCase("Closes the connection", async () => {
       const Dami = new DAMI(ami);
@@ -21,7 +21,24 @@ Rhum.testPlan("tests/unit/dami.ts", () => {
     });
   });
   Rhum.testSuite("connectAndLogin()", () => {
-    Rhum.testCase("Throws an error when `conn` is already set", () => {
+    Rhum.testCase("Throws an error when `conn` is already set", async () => {
+      let expectedErr = {
+        msg: "",
+        thrown: true
+      }
+      const Dami = new DAMI(ami)
+      await Dami.connectAndLogin(auth)
+      try {
+        await Dami.connectAndLogin(auth)
+      } catch (err) {
+        expectedErr.msg = err.message;
+        expectedErr.thrown =  true
+      }
+      Rhum.asserts.assertEquals(expectedErr, {
+        msg: "A connection has already been made",
+        thrown: true
+      })
+      Dami.close()
     });
     Rhum.testCase("Successfully connects and logs in to the AMI", async () => {
       const Dami = new DAMI(ami);
@@ -30,20 +47,47 @@ Rhum.testPlan("tests/unit/dami.ts", () => {
     });
   });
   Rhum.testSuite("to()", () => {
-    Rhum.testCase("Sends an event", () => {
+    Rhum.testCase("Sends an event", async () => {
+      const Dami = new DAMI(ami)
+      await Dami.connectAndLogin(auth)
+      await Dami.listen()
+      await Dami.to("GetConfig", {})
+      Dami.close()
     });
   });
   Rhum.testSuite("on()", () => {
     Rhum.testCase(
       "Registers a listener",
       () => {
+        const Dami = new DAMI(ami)
+        Dami.on("SomeEvent", (data) => {
+          console.log('got an event')
+        })
       },
     );
   });
   Rhum.testSuite("listen()", () => {
-    Rhum.testSuite("Listens for events", () => {
+    Rhum.testCase("Listens for events", () => {
     });
   });
+  // Rhum.testSuite("triggerEvent()", () => {
+  //   Rhum.testCase("Triggers and returns the expected event when using a callback", async () => {
+  //     const Dami = new DAMI(ami);
+  //     await Dami.connectAndLogin(auth);
+  //     //await Dami.listen()
+  //     let eventData;
+  //     // await Dami.triggerEvent("SIPPeers",  {}, (data) => {
+  //     //   eventData = data
+  //     //   //Dami.close()
+  //     // })
+  //     console.log('event data')
+  //     console.log(eventData)
+  //     Dami.close()
+  //   })
+  //   Rhum.testCase("Triggers and returns the expected event when assigning to a value", async () => {
+  //
+  //   })
+  // })
 });
 
 Rhum.run();

--- a/tests/unit/dami_test.ts
+++ b/tests/unit/dami_test.ts
@@ -24,21 +24,21 @@ Rhum.testPlan("tests/unit/dami_test.ts", () => {
     Rhum.testCase("Throws an error when `conn` is already set", async () => {
       let expectedErr = {
         msg: "",
-        thrown: true
-      }
-      const Dami = new DAMI(ami)
-      await Dami.connectAndLogin(auth)
+        thrown: true,
+      };
+      const Dami = new DAMI(ami);
+      await Dami.connectAndLogin(auth);
       try {
-        await Dami.connectAndLogin(auth)
+        await Dami.connectAndLogin(auth);
       } catch (err) {
         expectedErr.msg = err.message;
-        expectedErr.thrown =  true
+        expectedErr.thrown = true;
       }
       Rhum.asserts.assertEquals(expectedErr, {
         msg: "A connection has already been made",
-        thrown: true
-      })
-      Dami.close()
+        thrown: true,
+      });
+      Dami.close();
     });
     Rhum.testCase("Successfully connects and logs in to the AMI", async () => {
       const Dami = new DAMI(ami);
@@ -48,21 +48,21 @@ Rhum.testPlan("tests/unit/dami_test.ts", () => {
   });
   Rhum.testSuite("to()", () => {
     Rhum.testCase("Sends an event", async () => {
-      const Dami = new DAMI(ami)
-      await Dami.connectAndLogin(auth)
-      await Dami.listen()
-      await Dami.to("GetConfig", {})
-      Dami.close()
+      const Dami = new DAMI(ami);
+      await Dami.connectAndLogin(auth);
+      await Dami.listen();
+      await Dami.to("GetConfig", {});
+      Dami.close();
     });
   });
   Rhum.testSuite("on()", () => {
     Rhum.testCase(
       "Registers a listener",
       () => {
-        const Dami = new DAMI(ami)
+        const Dami = new DAMI(ami);
         Dami.on("SomeEvent", (data) => {
-          console.log('got an event')
-        })
+          console.log("got an event");
+        });
       },
     );
   });


### PR DESCRIPTION
Fixes #5 

Decided against having a trigger method, but the code exists (just commented out) as i felt it wasnt actually needed. Instead i reworked the internal code that will now properly send the correct event data back, such as the correct calls to a `peerEntry` handler